### PR TITLE
Feature/apitimestamp

### DIFF
--- a/Sources/FeatherCore/CRUD/Controllers/ListController.swift
+++ b/Sources/FeatherCore/CRUD/Controllers/ListController.swift
@@ -138,7 +138,7 @@ public extension ListController {
             guard hasAccess else {
                 return req.eventLoop.future(error: Abort(.forbidden))
             }
-            return listLoader.paginate(req).map { pc -> PaginationContainer<ListApi.ListObject> in
+            return listLoader.paginate(req, withDeleted: true).map { pc -> PaginationContainer<ListApi.ListObject> in
                 let api = ListApi()
                 let items = pc.map { api.mapList(model: $0 as! ListApi.Model) }
                 return items

--- a/Sources/FeatherCore/CRUD/Shared/ListLoader.swift
+++ b/Sources/FeatherCore/CRUD/Shared/ListLoader.swift
@@ -35,7 +35,7 @@ public struct ListLoader<T: FeatherModel>  {
         self.beforeQuery = beforeQuery
     }
 
-    public func paginate(_ req: Request) -> EventLoopFuture<PaginationContainer<T>> {
+    public func paginate(_ req: Request, withDeleted deleted: Bool = false) -> EventLoopFuture<PaginationContainer<T>> {
         var qb = T.query(on: req.db)
         if let beforeQuery = beforeQuery {
             qb = beforeQuery(req, qb)
@@ -65,7 +65,12 @@ public struct ListLoader<T: FeatherModel>  {
                 }
             }
         }
-
+        
+        /// Deleted
+        if deleted {
+            qb = qb.withDeleted()
+        }
+           
         /// pagination
         let listLimit: Int = max(req.query[limitKey] ?? limit, 1)
         let listPage: Int = max(req.query[pageKey] ?? page, 1)

--- a/Sources/FeatherCore/CRUD/Shared/TimestampFieldKeys.swift
+++ b/Sources/FeatherCore/CRUD/Shared/TimestampFieldKeys.swift
@@ -1,0 +1,15 @@
+//
+//  TimestampFieldKeys.swift
+//  
+//
+//  Created by Denis Martin on 01/05/2021.
+//
+
+public protocol TimestampFieldKeys { }
+
+public extension TimestampFieldKeys {
+    static var updated_at: FieldKey { "updated_at" }
+    static var created_at: FieldKey { "created_at" }
+    static var deleted_at: FieldKey { "deleted_at" }
+}
+


### PR DESCRIPTION
@tib Hello
I have been implementing the timestamp (with soft delete) & the ability to add start / end parameters to the query so you can retrieve specific range of changes.

Why I am implementing that, is for the API sync I am working on, I actually have a package that can be use for feather, with the possibility to be extended for anyone who create a module. it has it's own CoreData DB for offline support. The logic will be a follow:
- 1st Sync and store the Timestamp coming from the header (only for the list, for the get object won't make sense)
- Store the timestamp 
- add params to the next query start so you get only the changes from that date
{{SERVER}}/api/admin/blog/posts/?limit=10&start=1619885777
etc... 

I also support deleted object, so if something is deleted, it will actively be deleted from CoreData.

I will also create a PR on the Blog module. 

PS. Those are non breaking changes, and they do not affect anything, this is only for optional adoption.

Let me know what you think.

Deni
